### PR TITLE
Optimize Dockerfile for smaller image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
-node_modules
+*
+!*.js
+!*.ts
+!package-lock.json*
+!package.json
+!src
+!static

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,9 @@ name: Build and Push Docker Image
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - '*.*.*'
 
 env:
   REGISTRY: ghcr.io
@@ -16,12 +19,23 @@ jobs:
       packages: write
 
     steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-  
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -38,4 +52,5 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,9 +3,6 @@ name: Build and Push Docker Image
 on:
   release:
     types: [published]
-  push:
-    tags:
-      - '*.*.*'
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-bookworm@sha256:4b4e58e59c5e042928790c6fccd8ad16da6296bcc2e9924c56fba84a8e5ff662 AS build-env
 
 WORKDIR /app
 
@@ -11,3 +11,11 @@ COPY . .
 RUN npm run build
 
 CMD ["node", "build"]
+
+FROM gcr.io/distroless/nodejs20-debian12:nonroot@sha256:010cb788479147947d2515097bc9c8b77e12e77316f79a0d46e60c445905038b
+
+COPY --from=build-env /app /app
+
+WORKDIR /app
+
+CMD ["build/index.js"]


### PR DESCRIPTION
- Use Multistage build/Google Distroless as base image to make the resulting container image smaller
- Reduce the container build context with `.dockerignore`
- Use `docker/metadata-action` to tag the container images with versions